### PR TITLE
Update: Support staticcheck deprecation detection in golangci-lint

### DIFF
--- a/appcreds/appcreds.go
+++ b/appcreds/appcreds.go
@@ -76,6 +76,7 @@ func Create(ctx context.Context, m manipulate.Manipulator, namespace string, ac 
 }
 
 // NewWithAppCredential creates a new *gaia.AppCredential from an *AppCredential
+//
 // Deprecated: use Create instead
 func NewWithAppCredential(ctx context.Context, m manipulate.Manipulator, template *gaia.AppCredential) (*gaia.AppCredential, error) {
 	fmt.Println("DEPRECATED: NewWithAppCredential is deprecated in favor of Create instead")


### PR DESCRIPTION
#### Description
We can leverage golangci-lint's `staticcheck` to help detect and force migration from deprecated functions. To do this, we need to slightly modify how we declare this by having a commented out space between where we call deprecation and the function description.